### PR TITLE
feat: refactored to handle panic better

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -11,7 +11,6 @@ bincode = "1.3.3"
 bytemuck = "1.13.0"
 flate2 = "1.0.25"
 ggrs = "0.9.4"
-lazy_static = "1.4.0"
 libc = "0.2.139"
 pod = "0.5.0"
 rand = "0.8.5"
@@ -23,3 +22,5 @@ matchbox_socket = { version = "0.6.1", features = ["ggrs"] }
 futures = "0.3.28"
 futures-timer = "3.0.2"
 tokio = { version = "1.28.1", features = ["rt"] }
+backtrace = "0.3.68"
+once_cell = "1.18.0"

--- a/core/src/exts.rs
+++ b/core/src/exts.rs
@@ -1,0 +1,20 @@
+use std::sync::Mutex;
+
+use crate::{neplay::Netplay, reset_netplay_instance};
+
+pub trait MutexNetplayExtensions {
+    unsafe fn ensure_not_poisoned(&self);
+}
+
+impl MutexNetplayExtensions for Mutex<Netplay> {
+    unsafe fn ensure_not_poisoned(&self) {
+        let res = match self.lock() {
+            Ok(_) => Ok(()),
+            Err(_) => Err(()),
+        };
+
+        if res.is_err() {
+            reset_netplay_instance();
+        }
+    }
+}

--- a/core/src/ffi.rs
+++ b/core/src/ffi.rs
@@ -8,6 +8,7 @@ use crate::{
         action_result::ActionResult,
         unmanaged::{safe_bytes::SafeBytes, unmanaged_bytes::UnmanagedBytes},
     },
+    get_netplay_intance, has_netplay_disconnected,
     model::{
         ffi::{input_ffi::Inputs, netplay_request_ffi::NetplayRequests},
         game_state::GameState,
@@ -15,14 +16,14 @@ use crate::{
         netplay_request::NetplayRequest,
         network_stats::NetworkStats,
     },
-    Events, Status, NETPLAY, SHOULD_STOP_MATCHBOX_FUTURE,
+    Events, Status,
 };
 use std::ffi::CString;
 
 #[no_mangle]
 #[catch_status]
 pub unsafe extern "C" fn netplay_init(config: SafeBytes) -> Status {
-    let mut np = NETPLAY.lock().unwrap();
+    let mut np = get_netplay_intance().lock().unwrap();
 
     let safe_config = AppConfig::new(config);
 
@@ -32,77 +33,83 @@ pub unsafe extern "C" fn netplay_init(config: SafeBytes) -> Status {
 #[no_mangle]
 #[catch_status]
 pub extern "C" fn netplay_poll() -> Status {
-    let is_disconnected = is_disconnected();
-
-    if is_disconnected {
-        return Status::ko(Box::leak("Peer Disconnected!".to_string().into_boxed_str()));
+    if has_netplay_disconnected() {
+        return Status::msg("Peer Disconnected!");
     }
 
-    let mut np = NETPLAY.lock().unwrap();
+    let mut np = get_netplay_intance().lock().unwrap();
 
     np.poll_remote()
 }
 
 #[no_mangle]
-pub extern "C" fn netplay_events() -> Events {
-    let mut np = NETPLAY.lock().unwrap();
+pub unsafe extern "C" fn netplay_is_synchronized() -> Status {
+    let mut np = get_netplay_intance().lock().unwrap();
+
+    match np.is_synchronized() {
+        true => Status::ok(),
+        false => Status::ko("not synchronized"),
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn netplay_is_disconnected() -> Status {
+    match has_netplay_disconnected() {
+        true => Status::ok(),
+        false => Status::ko("not disconnected"),
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn netplay_events() -> Events {
+    let mut np = get_netplay_intance().lock().unwrap();
 
     return Events::new(np.events());
 }
 
 #[no_mangle]
-pub extern "C" fn status_info_free(s: *mut c_char) {
-    unsafe {
-        if s.is_null() {
-            return;
-        }
-        CString::from_raw(s)
-    };
+pub unsafe extern "C" fn status_info_free(s: *mut c_char) {
+    if s.is_null() {
+        return;
+    }
+    let _ = CString::from_raw(s);
 }
 
 #[no_mangle]
-pub extern "C" fn netplay_events_free(events: Events) {
-    unsafe {
-        if events.data.is_null() {
-            return;
-        }
-        let _ = Vec::from_raw_parts(events.data as *mut Events, events.len, events.cap);
-    };
+pub unsafe extern "C" fn netplay_events_free(events: Events) {
+    if events.data.is_null() {
+        return;
+    }
+    let _ = Vec::from_raw_parts(events.data as *mut Events, events.len, events.cap);
 }
 
 #[no_mangle]
-pub extern "C" fn netplay_advance_frame(input: Input) -> Status {
-    let is_disconnected = is_disconnected();
+pub unsafe extern "C" fn netplay_advance_frame(input: Input) -> Status {
+    let mut np = get_netplay_intance().lock().unwrap();
 
-    if !is_disconnected {
-        let mut np = NETPLAY.lock().unwrap();
+    let res = std::panic::catch_unwind(move || match np.advance_frame(input) {
+        Ok(_) => Status::ok(),
+        Err(e) => Status::ko(Box::leak(e.into_boxed_str())),
+    });
 
-        let res = std::panic::catch_unwind(move || match np.advance_frame(input) {
-            Ok(_) => Status::ok(),
-            Err(e) => Status::ko(Box::leak(e.into_boxed_str())),
-        });
-
-        match res {
-            Ok(status) => return status,
-            Err(e) => {
-                let error_msg = if let Some(s) = e.downcast_ref::<&str>() {
-                    s.to_string()
-                } else if let Some(s) = e.downcast_ref::<String>() {
-                    s.clone()
-                } else {
-                    "unknown error".to_string()
-                };
-                return Status::ko(Box::leak(error_msg.into_boxed_str()));
-            }
+    match res {
+        Ok(status) => return status,
+        Err(e) => {
+            let error_msg = if let Some(s) = e.downcast_ref::<&str>() {
+                s.to_string()
+            } else if let Some(s) = e.downcast_ref::<String>() {
+                s.clone()
+            } else {
+                "unknown error".to_string()
+            };
+            return Status::ko(Box::leak(error_msg.into_boxed_str()));
         }
     }
-
-    Status::ko(Box::leak("Peer Disconnected!".to_string().into_boxed_str()))
 }
 
 #[no_mangle]
-pub extern "C" fn netplay_get_requests() -> NetplayRequests {
-    let np = NETPLAY.lock().unwrap();
+pub unsafe extern "C" fn netplay_get_requests() -> NetplayRequests {
+    let np = get_netplay_intance().lock().unwrap();
 
     let requests = np.requests();
     let reqs = NetplayRequests::new(requests.clone());
@@ -113,23 +120,21 @@ pub extern "C" fn netplay_get_requests() -> NetplayRequests {
 }
 
 #[no_mangle]
-pub extern "C" fn netplay_requests_free(requests: NetplayRequests) {
-    unsafe {
-        if requests.data.is_null() {
-            return;
-        }
-        let _ = Vec::from_raw_parts(
-            requests.data as *mut NetplayRequest,
-            requests.len,
-            requests.len,
-        );
-    };
+pub unsafe extern "C" fn netplay_requests_free(requests: NetplayRequests) {
+    if requests.data.is_null() {
+        return;
+    }
+    let _ = Vec::from_raw_parts(
+        requests.data as *mut NetplayRequest,
+        requests.len,
+        requests.len,
+    );
 }
 
 #[no_mangle]
 #[catch_status]
 pub unsafe extern "C" fn netplay_save_game_state(game_state: SafeBytes) -> Status {
-    let mut np = NETPLAY.lock().unwrap();
+    let mut np = get_netplay_intance().lock().unwrap();
 
     let safe_game_state = GameState::new(game_state);
 
@@ -137,8 +142,8 @@ pub unsafe extern "C" fn netplay_save_game_state(game_state: SafeBytes) -> Statu
 }
 
 #[no_mangle]
-pub extern "C" fn netplay_advance_game_state() -> Inputs {
-    let mut np = NETPLAY.lock().unwrap();
+pub unsafe extern "C" fn netplay_advance_game_state() -> Inputs {
+    let mut np = get_netplay_intance().lock().unwrap();
 
     let inputs = np.handle_advance_frame_request();
     let inputs_ffi = Inputs::new(inputs.clone());
@@ -150,7 +155,8 @@ pub extern "C" fn netplay_advance_game_state() -> Inputs {
 #[no_mangle]
 #[catch_action_result]
 pub unsafe extern "C" fn netplay_load_game_state() -> ActionResult {
-    let mut np = NETPLAY.lock().unwrap();
+    let mut np = get_netplay_intance().lock().unwrap();
+
     np.handle_load_game_state_request()
 }
 
@@ -164,7 +170,7 @@ pub unsafe extern "C" fn netplay_inputs_free(inputs: Inputs) {
 
 #[no_mangle]
 pub unsafe extern "C" fn netplay_network_stats(network_stats: *mut NetworkStats) -> Status {
-    let mut np = NETPLAY.lock().unwrap();
+    let mut np = get_netplay_intance().lock().unwrap();
 
     match np.network_stats(network_stats) {
         Ok(_) => Status::ok(),
@@ -174,7 +180,7 @@ pub unsafe extern "C" fn netplay_network_stats(network_stats: *mut NetworkStats)
 
 #[no_mangle]
 pub unsafe extern "C" fn netplay_frames_ahead() -> i32 {
-    let mut np = NETPLAY.lock().unwrap();
+    let mut np = get_netplay_intance().lock().unwrap();
 
     match np.frames_ahead() {
         Ok(frames_ahead) => frames_ahead,
@@ -184,7 +190,7 @@ pub unsafe extern "C" fn netplay_frames_ahead() -> i32 {
 
 #[no_mangle]
 pub unsafe extern "C" fn netplay_free_game_state(safe_bytes: SafeBytes) {
-    let mut np = NETPLAY.lock().unwrap();
+    let mut np = get_netplay_intance().lock().unwrap();
 
     let slice = safe_bytes.slice();
     drop(slice);
@@ -194,40 +200,29 @@ pub unsafe extern "C" fn netplay_free_game_state(safe_bytes: SafeBytes) {
 
 #[no_mangle]
 pub unsafe extern "C" fn netplay_current_frame() -> i32 {
-    let np = NETPLAY.lock().unwrap();
+    let np = get_netplay_intance().lock().unwrap();
+
     np.game_state().frame()
 }
 
 #[no_mangle]
 #[catch_status]
 pub unsafe extern "C" fn netplay_reset() -> Status {
-    let mut np = NETPLAY.lock().unwrap();
+    let mut np = get_netplay_intance().lock().unwrap();
+
     np.reset()
 }
 
 #[no_mangle]
-pub extern "C" fn netplay_local_player_handle() -> i32 {
-    let np = NETPLAY.lock().unwrap();
+pub unsafe extern "C" fn netplay_local_player_handle() -> i32 {
+    let np = get_netplay_intance().lock().unwrap();
 
     np.local_player_handle()
 }
 
 #[no_mangle]
-pub extern "C" fn netplay_remote_player_handle() -> i32 {
-    let np = NETPLAY.lock().unwrap();
+pub unsafe extern "C" fn netplay_remote_player_handle() -> i32 {
+    let np = get_netplay_intance().lock().unwrap();
 
     np.remote_player_handle()
-}
-
-fn is_disconnected() -> bool {
-    match SHOULD_STOP_MATCHBOX_FUTURE.try_lock() {
-        Ok(should_stop) => {
-            if *should_stop {
-                return true;
-            }
-        }
-        Err(_) => {}
-    }
-
-    false
 }

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -57,7 +57,7 @@ pub fn catch_action_result(_attr: TokenStream, item: TokenStream) -> TokenStream
         unsafe fn #fn_name(#fn_args) #fn_return_type {
             match std::panic::catch_unwind(|| {
                 match #fn_body {
-                    Ok(gs) => ActionResult::ok(gs.data().to_safe_bytes()),
+                    Ok(sb) => ActionResult::ok(sb),
                     Err(e) => {
                         ActionResult::ko(e, UnmanagedBytes::empty().to_safe_bytes())
                     }
@@ -67,7 +67,11 @@ pub fn catch_action_result(_attr: TokenStream, item: TokenStream) -> TokenStream
                 Err(e) => {
                     if let Some(er) = e.downcast_ref::<&str>() {
                         return ActionResult::ko(er.to_string(), UnmanagedBytes::empty().to_safe_bytes());
-                    } else {
+                    }
+                    else if let Some(er) = e.downcast_ref::<String>() {
+                        return ActionResult::ko(er.to_string(), UnmanagedBytes::empty().to_safe_bytes());
+                    }
+                    else {
                         return ActionResult::ko("Unkown error".to_string(),UnmanagedBytes::empty().to_safe_bytes());
                     }
                 }


### PR DESCRIPTION
- switched lazy_static to once_cell (let us reinitialize the global var)
- Reset global netplay if the underlined mutex get poisoned (mostly because deconnexion)
- Better getter/setter to global Netplay
- 2 new fn to handle disconnect/ggrs session running
- Removed panic when retrieving session, instead return option